### PR TITLE
[ODE] adminv2 : recherche par UAI

### DIFF
--- a/projects/ngx-ode-ui/src/lib/components/item-tree/item-tree.component.html
+++ b/projects/ngx-ode-ui/src/lib/components/item-tree/item-tree.component.html
@@ -4,16 +4,23 @@
     <a href="javascript:void(0)" (click)="selectItem(item)" *ngIf="!checkboxMode">
       <i class="opener" (click)="toggleFold($event, item)"
          *ngIf="!isFlattened() && hasChildren(item) && !disableOpener"></i>
-      {{ display(item) }}
+      <span *ngIf="displayProperty">{{ display(item) }}</span>
+      <span *ngIf="displayTemplate">
+        <ng-template [ngTemplateOutlet]="displayTemplate" [ngTemplateOutletContext]="{$implicit: item}"></ng-template>
+      </span>
     </a>
     <div class="checkbox__item" *ngIf="checkboxMode">
       <input id="all" type="checkbox" [(ngModel)]="item.check" ngDefaultControl>
-      <label for="all" (click)="checkItem(item)">{{display(item)}}</label>
+      <label *ngIf="displayProperty" for="all" (click)="checkItem(item)">{{display(item)}}</label>
+      <span *ngIf="displayTemplate">
+        <ng-template [ngTemplateOutlet]="displayTemplate" [ngTemplateOutletContext]="{$implicit: item}"></ng-template>
+      </span>
     </div>
     <ode-item-tree
       [items]="getChildren(item)"
       [children]="childrenProperty"
       [display]="displayProperty"
+      [displayTemplate]="displayTemplate"
       [filter]="filter"
       [order]="order"
       [reverse]="reverse"

--- a/projects/ngx-ode-ui/src/lib/components/item-tree/item-tree.component.ts
+++ b/projects/ngx-ode-ui/src/lib/components/item-tree/item-tree.component.ts
@@ -1,5 +1,5 @@
 import { OdeComponent } from 'ngx-ode-core';
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild, Injector } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ContentChild, TemplateRef, Injector } from '@angular/core';
 
 @Component({
     selector: 'ode-item-tree',
@@ -20,6 +20,7 @@ export class ItemTreeComponent<T> extends OdeComponent implements OnInit {
     @Input('children') childrenProperty = 'children';
     // Property to display in the list
     @Input('display') displayProperty = 'label';
+    @Input() displayTemplate: TemplateRef<any>;
     // Filter pipe argument
     @Input() filter: (Object | string | Function) = '';
     // OrderBy pipe argument
@@ -110,8 +111,8 @@ export class ItemTreeComponent<T> extends OdeComponent implements OnInit {
         return this.disableOpener ? !this.isSelected(item) : this.unfolded.indexOf(item) < 0;
     }
 
-    public display(item) {
-        return item[this.displayProperty];
+    public display(item: T) {
+        return this.displayProperty && item[this.displayProperty];
     }
 
     public getChildren(item) {


### PR DESCRIPTION
Le composant ode-item-tree accepte désormais une propriété displayTemplate permettant de customiser plus encore l'apparence du composant. la propriété 'display' peut toujours être utilisée. Il n'est pas interdit d'utiliser les deux propriétés simultanément bien que ce soit rarement souhaitable.