### PR TITLE
chore(ngx-ode-libs): #COCO-5012, fix package peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build-ngx-ode-core": "ng build ngx-ode-core",
     "build-ngx-ode-sijil": "ng build ngx-ode-sijil",
     "build-ngx-ode-ui": "ng build ngx-ode-ui",
+    "sync-versions": "node scripts/sync-versions.js",
+    "prebuild": "npm run sync-versions",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/projects/ngx-ode-ui/package.json
+++ b/projects/ngx-ode-ui/package.json
@@ -7,7 +7,7 @@
   "peerDependencies": {
     "@angular/common": "^14.1.1",
     "@angular/core": "^14.1.1",
-    "ngx-ode-core": "4.8.0-develop-b2school.4",
-    "ngx-ode-sijil": "4.8.0-develop-b2school.4"
+    "ngx-ode-core": "4.8.0-develop-b2school.5",
+    "ngx-ode-sijil": "4.8.0-develop-b2school.5"
   }
 }

--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+
+/**
+ * Script pour synchroniser les versions des peerDependencies dans le monorepo ngx-ode-libs
+ *
+ * Ce script lit la version de chaque package et met à jour les peerDependencies
+ * pour s'assurer que tous les packages internes référencent la même version.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Chemins vers les packages
+const PACKAGES = [
+  {
+    name: "ngx-ode-core",
+    path: path.join(__dirname, "../projects/ngx-ode-core/package.json"),
+  },
+  {
+    name: "ngx-ode-sijil",
+    path: path.join(__dirname, "../projects/ngx-ode-sijil/package.json"),
+  },
+  {
+    name: "ngx-ode-ui",
+    path: path.join(__dirname, "../projects/ngx-ode-ui/package.json"),
+  },
+];
+
+// Fonction pour lire un package.json
+function readPackageJson(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(content);
+  } catch (error) {
+    console.error(`Erreur lors de la lecture de ${filePath}:`, error.message);
+    process.exit(1);
+  }
+}
+
+// Fonction pour écrire un package.json
+function writePackageJson(filePath, data) {
+  try {
+    const content = JSON.stringify(data, null, 2) + "\n";
+    fs.writeFileSync(filePath, content, "utf8");
+    console.log(`✓ Mis à jour: ${filePath}`);
+  } catch (error) {
+    console.error(`Erreur lors de l'écriture de ${filePath}:`, error.message);
+    process.exit(1);
+  }
+}
+
+// Fonction principale
+function syncVersions() {
+  console.log("🔄 Synchronisation des versions des peerDependencies...\n");
+
+  // Étape 1: Lire toutes les versions
+  const versions = {};
+  PACKAGES.forEach((pkg) => {
+    const packageJson = readPackageJson(pkg.path);
+    versions[pkg.name] = packageJson.version;
+    console.log(`📦 ${pkg.name}: ${packageJson.version}`);
+  });
+
+  console.log("\n🔧 Mise à jour des peerDependencies...\n");
+
+  // Étape 2: Mettre à jour les peerDependencies
+  let hasChanges = false;
+
+  PACKAGES.forEach((pkg) => {
+    const packageJson = readPackageJson(pkg.path);
+
+    if (!packageJson.peerDependencies) {
+      return;
+    }
+
+    let modified = false;
+
+    // Vérifier chaque peerDependency
+    Object.keys(packageJson.peerDependencies).forEach((depName) => {
+      // Si c'est un package interne, synchroniser la version
+      if (versions[depName]) {
+        const currentVersion = packageJson.peerDependencies[depName];
+        const newVersion = versions[depName];
+
+        if (currentVersion !== newVersion) {
+          console.log(
+            `  ${pkg.name}: ${depName} ${currentVersion} → ${newVersion}`
+          );
+          packageJson.peerDependencies[depName] = newVersion;
+          modified = true;
+          hasChanges = true;
+        }
+      }
+    });
+
+    // Écrire le fichier seulement s'il y a eu des modifications
+    if (modified) {
+      writePackageJson(pkg.path, packageJson);
+    }
+  });
+
+  if (!hasChanges) {
+    console.log(
+      "✨ Aucune modification nécessaire - toutes les versions sont déjà synchronisées."
+    );
+  } else {
+    console.log("\n✨ Synchronisation terminée avec succès!");
+  }
+}
+
+// Exécuter le script
+syncVersions();


### PR DESCRIPTION
Lors d'une livraison sur recette-release, la version du package.json de ngx-ode-libs est incrémentée
ainsi que celle des 3 sous-modules (core, sijil et ui)

Mais ngx-ode-ui déclare les 2 autres en peerDependency et là, le n° de version ne s'incrémente pas toujours.
Or, on veut que les numéros de versions soient bien identiques, sinon le build de entcore échoue ensuite.

Copilot propose cette solution :

📝 Fichiers créés/modifiés
1. sync-versions.js

Script Node.js qui :
- Lit les versions de tous les packages (ngx-ode-core, ngx-ode-sijil, ngx-ode-ui)
- Met à jour automatiquement les peerDependencies pour qu'elles correspondent aux versions actuelles
- Affiche un rapport détaillé des modifications

2. package.json

Ajout de deux scripts :
- "sync-versions": exécute manuellement la synchronisation
- "prebuild": s'exécute automatiquement avant chaque build pour garantir la cohérence

✅ Tests
Le script a détecté et corrigé les versions obsolètes dans ngx-ode-ui :

ngx-ode-core: 4.8.0-develop-b2school.4 → 4.8.0-develop-b2school.5
ngx-ode-sijil: 4.8.0-develop-b2school.4 → 4.8.0-develop-b2school.5

🚀 Utilisation

- Automatique : La synchronisation se fait automatiquement avant chaque npm run build
- Manuel : Vous pouvez aussi l'exécuter quand vous voulez :

Maintenant, chaque fois que vous modifiez la version d'un package, il suffit de lancer le script pour que toutes les peerDependencies soient mises à jour automatiquement !